### PR TITLE
Use isNone to check for passed properties. Run assert before calling super in init.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ember install ember-required-properties
 Import the mixin anywhere you want to require properties:
 
 ```
-import RequiredProperties from 'ember-required-properties'
+import RequiredProperties from 'ember-required-properties/mixins/required-properties';
 
 export Component.extend(RequiredProperties, {
   requiredProperties: ['one', 'two']

--- a/addon/mixins/required-properties.js
+++ b/addon/mixins/required-properties.js
@@ -3,7 +3,7 @@ import assertRequiredProperties from '../utils/assert-required-properties';
 
 export default Mixin.create({
   init() {
-    this._super(...arguments);
     assertRequiredProperties(this);
+    this._super(...arguments);
   }
 });

--- a/addon/utils/assert-required-properties.js
+++ b/addon/utils/assert-required-properties.js
@@ -1,6 +1,6 @@
 import get from 'ember-metal/get';
 import { assert } from 'ember-metal/utils';
-import { isEmpty } from 'ember-utils';
+import { isEmpty, isNone } from 'ember-utils';
 import arrayToSentence from './array-to-sentence';
 
 /**
@@ -21,7 +21,7 @@ export default function assertRequiredProperties(object) {
 
   let definedProperties = requiredProperties.filter((a) => {
     let providedValue = get(object, a);
-    return typeof(providedValue) !== 'undefined';
+    return !isNone(providedValue);
   });
 
   let hasRequiredProperties = definedProperties.length === requiredProperties.length;


### PR DESCRIPTION
Previously we were checking for 'undefined'. This also changes the order things happen, as we dont want to continue init if the required properties are not present.

- update readme to correct syntax
- use isNone to check if properties are passed
- run assertion before calling super